### PR TITLE
Database Creation Bugfixes

### DIFF
--- a/Headers/Databases/Database.h
+++ b/Headers/Databases/Database.h
@@ -457,8 +457,8 @@ public:
     void addFileDictionaryAttributes(QString chosenClass);
     void addNewInstance();
     void editAttributeValue(int selectedInstanceID, QString instanceName, QString attributeName);
-    dictItem* getInstance(QString itemName);
-    dictItem* getInstance(int instanceID);
+    int getInstance(QString itemName);
+    int getInstance(int instanceID);
     void copyOrDeleteInstance(int instanceID);
     void copyInstance(int instanceID);
 

--- a/Source/Databases/DataHandler.cpp
+++ b/Source/Databases/DataHandler.cpp
@@ -204,6 +204,7 @@ void DataHandler::loadLevels(){
 
     foreach(exPickupLocation currentLocation, tempLocations){
         currentLocation.uniqueID = id;
+        currentLocation.originalDatabaseInstance = tempLocations[id].gameID[1];
         //addedLocation.setAttribute("PickupToSpawn", "0");
 
         //to be placed inside the switch:
@@ -705,7 +706,7 @@ void DataHandler::loadLevels(){
     qDebug() << Q_FUNC_INFO << "Total loaded locations:" << loadedLocations.size();
     for(int i = 0; i < loadedLocations.size(); i++){
         QVector3D debugPosition = loadedLocations[i].position;
-        qDebug() << Q_FUNC_INFO << i << " " << loadedLocations[i].uniqueID << "  " << loadedLocations[i].linkedLocationID << "    "
+        qDebug() << Q_FUNC_INFO << i << "   " << loadedLocations[i].originalDatabaseInstance << "  " << loadedLocations[i].uniqueID << "   " << loadedLocations[i].linkedLocationID << "    "
                  << loadedLocations[i].gameID[0] << "    " << loadedLocations[i].locationName << "    " << debugPosition.x()
                  << "   " << debugPosition.y() << "  " << debugPosition.z();
     }

--- a/Source/Databases/DatabaseItems.cpp
+++ b/Source/Databases/DatabaseItems.cpp
@@ -1338,6 +1338,8 @@ int dictItem::addAttribute(QString itemType){
 
     genericData->type = itemType;
     genericData->name = dialogCreateAttribute->lineOption->text();
+    genericData->inherited = false;
+    genericData->active = false;
 
     qDebug() << Q_FUNC_INFO << "data value set to:" << genericData->display();
 


### PR DESCRIPTION
Multiple bugfixes for the Database system, including:
New enum values can have new values added
Copying an instance will no longer cause a crash
Instances being added to a text database will have the correct instance index